### PR TITLE
Enable CI runs on pushes to PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,9 +1,7 @@
 name: Build pipeline
 
 on:
-  push:
-    branch:
-      - master
+  push: {}
 
 jobs:
   Testing:


### PR DESCRIPTION
To catch issues **before** they make it to main branch. Enable the testing CI to run on branches other than "master" to facilitate this.